### PR TITLE
Close #1

### DIFF
--- a/number-slider/src/main/java/com/leeweeder/numberslider/NumberSlider.kt
+++ b/number-slider/src/main/java/com/leeweeder/numberslider/NumberSlider.kt
@@ -246,7 +246,8 @@ fun NumberSlider(
                 }
             }) {
             scope.launch {
-                val itemIndex = numbers.indexOf(textFieldValue.value.text.toFloat())
+                val floatValue = textFieldValue.value.text.toFloatOrNull() ?: return@launch
+                val itemIndex = numbers.indexOf(floatValue)
                 if (itemIndex >= 0) {
                     listState.scrollToItem(index = itemIndex)
 


### PR DESCRIPTION
Instead of the `textFieldValue.value.text`, converted to `Float`, directly assigned as the `itemIndex`, introduced early return if conversion to `Float` fails.